### PR TITLE
Feature: Geocoding API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Cargo.lock
 
 # Others
 addresses/
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 csv = "1.3.0"
 google_maps = "3.5.3"
 serde = { version = "1.0.203", features = ["derive"] }
+thiserror = "1.0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ csv = "1.3.0"
 google_maps = "3.5.3"
 serde = { version = "1.0.203", features = ["derive"] }
 thiserror = "1.0.61"
-tokio = "1.38.0"
+tokio = { version = "1.38.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ csv = "1.3.0"
 google_maps = "3.5.3"
 serde = { version = "1.0.203", features = ["derive"] }
 thiserror = "1.0.61"
+tokio = "1.38.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ google_maps = "3.5.3"
 serde = { version = "1.0.203", features = ["derive"] }
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["full"] }
+tokio-macros = "2.3.0"

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,17 +1,17 @@
 use csv::ReaderBuilder;
 use serde::Deserialize;
-use std::{error::Error, f64, fmt, fs::File, io::BufReader, path::Path};
+use std::{error::Error, fs::File, io::BufReader, path::Path};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Deserialize)]
 pub struct Address {
-    name: String,
-    address: String,
-    city: String,
-    zip: String,
-    administrative_area_level1: String,
-    administrative_area_level2: String,
-    lat: f64,
-    lng: f64,
+    name: Option<String>,
+    address: Option<String>,
+    city: Option<String>,
+    zip: Option<String>,
+    administrative_area_level1: Option<String>,
+    administrative_area_level2: Option<String>,
+    lat: Option<google_maps::prelude::Decimal>,
+    lng: Option<google_maps::prelude::Decimal>,
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
@@ -37,92 +37,45 @@ impl Addresses {
         Ok(Addresses { addresses })
     }
 
-    pub fn generate_diff_csv(
-        &self,
-        differences: &[(Address, Address)],
-        output_path: &str,
-    ) -> Result<(), Box<dyn Error>> {
-        let mut wtr = csv::Writer::from_path(output_path)?;
-
-        wtr.write_record([
-            "name",
-            "old_address",
-            "old_city",
-            "old_zip",
-            "old_lat",
-            "old_lng",
-            "new_address",
-            "new_city",
-            "new_zip",
-            "new_lat",
-            "new_lng",
-        ])?;
-
-        for (old, new) in differences {
-            wtr.write_record([
-                &old.name,
-                &old.address,
-                &old.city,
-                &old.zip,
-                &old.lat.to_string(),
-                &old.lng.to_string(),
-                &new.address,
-                &new.city,
-                &new.zip,
-                &new.lat.to_string(),
-                &new.lng.to_string(),
-            ])?;
-        }
-
-        wtr.flush()?;
-        Ok(())
+    pub fn generate_diff_csv(&self) -> Result<(), Box<dyn Error>> {
+        todo!()
     }
 
     pub fn display(&self) {
         for (index, address) in self.addresses.iter().enumerate() {
-            println!("Address {}: {}", index + 1, address);
+            println!(
+                "Address {}: {}",
+                index + 1,
+                address
+                    .get_formatted_address()
+                    .expect("original file address should be correct")
+            );
         }
     }
 }
 
 impl Address {
-    /// This function is not complete yet, probably missing more details
-    pub fn obj_to_string(&self) -> String {
-        let str = self.address.clone()
-            + ", "
-            + self.city.clone().as_str()
-            + ", "
-            + self.zip.clone().as_str();
-
-        str
+    pub fn get_formatted_address(&self) -> Option<String> {
+        Some(format!(
+            "{}, {}, {}, {}, {}, {}, {}, {}",
+            self.name.clone()?,
+            self.address.clone()?,
+            self.city.clone()?,
+            self.zip.clone()?,
+            self.administrative_area_level1.clone()?,
+            self.administrative_area_level2.clone()?,
+            self.lat.clone()?.to_string(),
+            self.lng.clone()?.to_string(),
+        ))
     }
 
-    pub fn get_address_with_site_name(&self) -> String {
-        let str = self.name.clone()
-            + ", "
-            + self.address.clone().as_str()
-            + ", "
-            + self.city.clone().as_str()
-            + ", "
-            + self.zip.clone().as_str();
-
-        str
-    }
-}
-
-impl fmt::Display for Address {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Site: {}, Street: {}, City: {}, ZIP: {}, Area 1: {}, Area 2: {}, Lat: {}, Lng: {}",
-            self.name,
-            self.address,
-            self.city,
-            self.zip,
-            self.administrative_area_level1,
-            self.administrative_area_level2,
-            self.lat,
-            self.lng
-        )
+    pub fn get_address_with_site_name(&self) -> Option<String> {
+        Some(format!(
+            "{}, {}, {}, {}",
+            self.name.clone()?,
+            self.address.clone()?,
+            self.city.clone()?,
+            self.zip.clone()?
+        ))
     }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -96,6 +96,18 @@ impl Address {
 
         str
     }
+
+    pub fn get_address_with_site_name(&self) -> String {
+        let str = self.name.clone()
+            + ", "
+            + self.address.clone().as_str()
+            + ", "
+            + self.city.clone().as_str()
+            + ", "
+            + self.zip.clone().as_str();
+
+        str
+    }
 }
 
 impl fmt::Display for Address {

--- a/src/address.rs
+++ b/src/address.rs
@@ -86,6 +86,7 @@ impl Addresses {
 }
 
 impl Address {
+    /// This function is not complete yet, probably missing more details
     pub fn obj_to_string(&self) -> String {
         let str = self.address.clone()
             + ", "

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,6 @@
 use csv::ReaderBuilder;
 use serde::Deserialize;
-use std::{error::Error, f64, fmt, fs::File, io::BufReader, path::Path};
+use std::{error::Error, f64, fmt, fs::File, io::BufReader, path::Path, str::FromStr};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Deserialize)]
 pub struct Address {
@@ -82,6 +82,18 @@ impl Addresses {
         for (index, address) in self.addresses.iter().enumerate() {
             println!("Address {}: {}", index + 1, address);
         }
+    }
+}
+
+impl Address {
+    pub fn obj_to_string(&self) -> String {
+        let str = self.address.clone()
+            + ", "
+            + self.city.clone().as_str()
+            + ", "
+            + self.zip.clone().as_str();
+
+        str
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,6 @@
 use csv::ReaderBuilder;
 use serde::Deserialize;
-use std::{error::Error, f64, fmt, fs::File, io::BufReader, path::Path, str::FromStr};
+use std::{error::Error, f64, fmt, fs::File, io::BufReader, path::Path};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Deserialize)]
 pub struct Address {
@@ -16,7 +16,7 @@ pub struct Address {
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Addresses {
-    addresses: Vec<Address>,
+    pub addresses: Vec<Address>,
 }
 
 impl Addresses {

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -72,7 +72,7 @@ impl MyGeocoding {
 
         println!("Maps API found: {:#?}", search_result);
 
-        let parsed_address = self.parse_geocoding_result(
+        let parsed_address = AddressResult::parse_geocoding_result(
             search_result
                 .results
                 .first()
@@ -82,8 +82,10 @@ impl MyGeocoding {
 
         Ok(())
     }
+}
 
-    fn parse_geocoding_result(&self, result: &Geocoding) -> AddressResult {
+impl AddressResult {
+    pub fn parse_geocoding_result(result: &Geocoding) -> AddressResult {
         // struct parts bc crate author committed a crime (vec as enum)
         let mut street_number = None;
         let mut route = None;
@@ -129,11 +131,5 @@ impl MyGeocoding {
             lat: result.geometry.location.lat,
             lng: result.geometry.location.lng,
         }
-    }
-}
-
-impl AddressResult {
-    pub fn parse_to_address_obj(&self) {
-        todo!()
     }
 }

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -19,6 +19,10 @@ pub enum GeocodingError {
 }
 
 impl MyGeocoding {
+    /// Initializes a new instance of `MyGeocoding`
+    /// ## Arguments
+    /// This function automatically searches for an `env` variable called `GOOGLE_MAPS_API_KEY`. It
+    /// returns a custom `GeocodingError` if it is not found.
     pub fn new() -> Result<Self, GeocodingError> {
         let api_key = env::var("GOOGLE_MAPS_API_KEY")?;
         let map_client = GoogleMapsClient::try_new(api_key)?;
@@ -26,6 +30,12 @@ impl MyGeocoding {
         Ok(MyGeocoding { map_client })
     }
 
+    /// Searches for the passed `address_obj` argument.
+    /// ## Arguments
+    /// `address_obj` --> an `Address` object containing the needed information
+    /// ## Returning
+    /// _Not implemented yet_
+    /// Returns the **non parsed** found address as a string and the lat and lng
     pub async fn get_address_from_google(&self, address_obj: Address) {
         let radius: u32 = 5000;
 

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -33,7 +33,7 @@ impl MyGeocoding {
     /// returns a custom `GeocodingError` if it is not found.
     pub fn new() -> Result<Self, GeocodingError> {
         let api_key = env::var("GOOGLE_MAPS_API_KEY")?;
-        let map_client = GoogleMapsClient::try_new(api_key)?;
+        let map_client = GoogleMapsClient::try_new(api_key)?.build();
 
         let address_results = vec![];
 
@@ -50,15 +50,15 @@ impl MyGeocoding {
     /// _Not implemented yet_
     /// Returns the **non parsed** found address as a string and the lat and lng
     pub async fn get_address_from_google(&self, address_obj: Address) {
-        let radius: u32 = 50000; // not sure how to use radius
         let address_to_search = address_obj.obj_to_string();
 
         println!("{}", address_to_search);
 
-        // TODO: await here
         let search_result = self
             .map_client
-            .text_search(address_obj.obj_to_string(), radius)
+            .geocoding()
+            .with_region(Region::France)
+            .with_address(address_to_search)
             .execute()
             .await;
 

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -50,7 +50,10 @@ impl MyGeocoding {
     /// _Not implemented yet_
     /// Returns the **non parsed** found address as a string and the lat and lng
     pub async fn get_address_from_google(&self, address_obj: Address) {
-        let radius: u32 = 5000; // not sure how to use radius
+        let radius: u32 = 50000; // not sure how to use radius
+        let address_to_search = address_obj.obj_to_string();
+
+        println!("{}", address_to_search);
 
         // TODO: await here
         let search_result = self

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -1,0 +1,22 @@
+use google_maps::prelude::*;
+use google_maps::{geocoding::Geocoding, ClientSettings};
+use std::env;
+
+#[derive(Debug)]
+pub struct MyGeocoding {
+    map_client: GoogleMapsClient,
+}
+
+impl MyGeocoding {
+    pub fn new() -> Result<Self, Erra> {
+        let google_api_key = env::var("GOOGLE_MAPS_API_KEY");
+
+        match env::var("GOOGLE_MAPS_API_KEY") {
+            Ok(api_key) => {
+                let map_client = GoogleMapsClient::new(api_key);
+                return Ok(MyGeocoding { map_client });
+            }
+            Err(err) => return Err(err.to_string()),
+        }
+    }
+}

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -22,11 +22,16 @@ impl MyGeocoding {
     pub fn new() -> Result<Self, GeocodingError> {
         let api_key = env::var("GOOGLE_MAPS_API_KEY")?;
         let map_client = GoogleMapsClient::try_new(api_key)?;
+
         Ok(MyGeocoding { map_client })
     }
 
     pub fn get_address_from_google(&self, address_obj: Address) {
+        let radius: u32 = 5000;
+
+        /// TODO: await here
         self.map_client
-            .text_search("123 Main street".to_string(), 50000);
+            .text_search(address_obj.obj_to_string(), radius)
+            .execute();
     }
 }

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -30,9 +30,12 @@ impl MyGeocoding {
         let radius: u32 = 5000;
 
         // TODO: await here
-        self.map_client
+        let search_result = self
+            .map_client
             .text_search(address_obj.obj_to_string(), radius)
             .execute()
             .await;
+
+        println!("{:#?}", search_result);
     }
 }

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -26,12 +26,13 @@ impl MyGeocoding {
         Ok(MyGeocoding { map_client })
     }
 
-    pub fn get_address_from_google(&self, address_obj: Address) {
+    pub async fn get_address_from_google(&self, address_obj: Address) {
         let radius: u32 = 5000;
 
-        /// TODO: await here
+        // TODO: await here
         self.map_client
             .text_search(address_obj.obj_to_string(), radius)
-            .execute();
+            .execute()
+            .await;
     }
 }

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -2,6 +2,8 @@ use google_maps::prelude::*;
 use std::env;
 use thiserror::Error;
 
+use crate::address::Address;
+
 #[derive(Debug)]
 pub struct MyGeocoding {
     map_client: GoogleMapsClient,
@@ -21,5 +23,10 @@ impl MyGeocoding {
         let api_key = env::var("GOOGLE_MAPS_API_KEY")?;
         let map_client = GoogleMapsClient::try_new(api_key)?;
         Ok(MyGeocoding { map_client })
+    }
+
+    pub fn get_address_from_google(&self, address_obj: Address) {
+        self.map_client
+            .text_search("123 Main street".to_string(), 50000);
     }
 }

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -5,8 +5,16 @@ use thiserror::Error;
 use crate::address::Address;
 
 #[derive(Debug)]
+pub struct AddressResult {
+    search_result: String,
+    lat: u32,
+    lng: u32,
+}
+
+#[derive(Debug)]
 pub struct MyGeocoding {
     map_client: GoogleMapsClient,
+    address_results: Vec<AddressResult>,
 }
 
 #[derive(Error, Debug)]
@@ -27,7 +35,12 @@ impl MyGeocoding {
         let api_key = env::var("GOOGLE_MAPS_API_KEY")?;
         let map_client = GoogleMapsClient::try_new(api_key)?;
 
-        Ok(MyGeocoding { map_client })
+        let address_results = vec![];
+
+        Ok(MyGeocoding {
+            map_client,
+            address_results,
+        })
     }
 
     /// Searches for the passed `address_obj` argument.
@@ -37,7 +50,7 @@ impl MyGeocoding {
     /// _Not implemented yet_
     /// Returns the **non parsed** found address as a string and the lat and lng
     pub async fn get_address_from_google(&self, address_obj: Address) {
-        let radius: u32 = 5000;
+        let radius: u32 = 5000; // not sure how to use radius
 
         // TODO: await here
         let search_result = self
@@ -47,5 +60,13 @@ impl MyGeocoding {
             .await;
 
         println!("{:#?}", search_result);
+
+        // TODO: add to the `address_results` array
+    }
+}
+
+impl AddressResult {
+    pub fn parse_to_address_obj(&self) {
+        todo!()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let geocoding = MyGeocoding::new().expect("API key should be an env variable");
+    let mut geocoding = MyGeocoding::new().expect("API key should be an env variable");
 
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
     old_addresses.display();
@@ -30,7 +30,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // TODO: remove the following once the program is finished (also maybe test with a bigger
     // sample)
     if !old_addresses.addresses.is_empty() {
-        geocoding
+        // let _ to remove warning about using Result
+        let _ = geocoding
             .get_address_from_google(
                 old_addresses
                     .addresses

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,37 @@
-use std::env;
+use std::{env, error::Error};
 
 use address::Addresses;
+use geocoding::{GeocodingError, MyGeocoding};
 
 mod address;
 mod geocoding;
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
         return Err(
-            "Error: Must have one argument. Use: `cargo run path/to/file.csv`, `csv` only"
-                .to_string(),
+            "Error: Must have one argument. Use: `cargo run path/to/file.csv`, `csv` only".into(),
         );
     }
 
+    let geocoding = MyGeocoding::new()?;
+
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
-
     old_addresses.display();
-
     Ok(())
+
+    // match MyGeocoding::new() {
+    //     Ok(geocoding) => {
+    //         // Use the geocoding instance
+    //     }
+    //     Err(e) => match e {
+    //         GeocodingError::EnvVarError(env_err) => {
+    //             return Err("Environment variable error".into());
+    //         }
+    //         GeocodingError::GoogleMapsError(maps_err) => {
+    //             return Err("Google Maps API error".into());
+    //         }
+    //     },
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use address::Addresses;
 
 mod address;
+mod geocoding;
 
 fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,23 +15,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let geocoding = MyGeocoding::new()?;
+    let geocoding = MyGeocoding::new().expect("given API key should be valid");
 
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
     old_addresses.display();
-    Ok(())
 
-    // match MyGeocoding::new() {
-    //     Ok(geocoding) => {
-    //         // Use the geocoding instance
-    //     }
-    //     Err(e) => match e {
-    //         GeocodingError::EnvVarError(env_err) => {
-    //             return Err("Environment variable error".into());
-    //         }
-    //         GeocodingError::GoogleMapsError(maps_err) => {
-    //             return Err("Google Maps API error".into());
-    //         }
-    //     },
-    // }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let geocoding = MyGeocoding::new().expect("given API key should be valid");
+    let geocoding = MyGeocoding::new().expect("API key should be an env variable");
 
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
     old_addresses.display();

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut geocoding = MyGeocoding::new().expect("API key should be an env variable");
 
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
+
+    // debugging print
     old_addresses.display();
 
     // TODO: This is for later once one call is working

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //     geocoding.get_address_from_google(addr.clone());
     // }
 
+    // For now, checking only one address for testing purposes and not flood with API calls
+    // TODO: remove the following once the program is finished (also maybe test with a bigger
+    // sample)
     if !old_addresses.addresses.is_empty() {
         geocoding
             .get_address_from_google(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use geocoding::MyGeocoding;
 mod address;
 mod geocoding;
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
@@ -26,14 +27,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     // }
 
     if !old_addresses.addresses.is_empty() {
-        geocoding.get_address_from_google(
-            old_addresses
-                .addresses
-                .clone()
-                .first()
-                .expect("There should be at least 1 address")
-                .clone(),
-        );
+        geocoding
+            .get_address_from_google(
+                old_addresses
+                    .addresses
+                    .clone()
+                    .first()
+                    .expect("There should be at least 1 address")
+                    .clone(),
+            )
+            .await;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
     old_addresses.display();
 
+    // TODO: This is for later once one call is working
+    // for addr in &old_addresses.addresses {
+    //     geocoding.get_address_from_google(addr.clone());
+    // }
+
     if !old_addresses.addresses.is_empty() {
         geocoding.get_address_from_google(
             old_addresses
@@ -28,7 +33,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .first()
                 .expect("There should be at least 1 address")
                 .clone(),
-        )
+        );
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{env, error::Error};
 
 use address::Addresses;
-use geocoding::{GeocodingError, MyGeocoding};
+use geocoding::MyGeocoding;
 
 mod address;
 mod geocoding;
@@ -19,6 +19,17 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
     old_addresses.display();
+
+    if !old_addresses.addresses.is_empty() {
+        geocoding.get_address_from_google(
+            old_addresses
+                .addresses
+                .clone()
+                .first()
+                .expect("There should be at least 1 address")
+                .clone(),
+        )
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Adding a protocol to call the `Google Maps API` and retrieve the correct address.

## TODO

- [x] Retrieving the`GOOGLE_MAPS_API_KEY` from the `env`
- [x] Initiating the `GoogleMapsClient`
- [x] Transforming the `Address` struct into what `GoogleMapsClient` expects
- [x] Make the request to the `API`
- [x] Returning the found: address (as a `string`) as well as the latitude and longitude (as a `[number, number]`?)
  - Can be its own `Struct`?
