### PR TITLE
Feature: Generate a `.csv` file with the results from the Google Maps API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ Cargo.lock
 # Others
 addresses/
 .env
+results/
+*.csv

--- a/src/address.rs
+++ b/src/address.rs
@@ -54,7 +54,12 @@ impl Addresses {
         Ok(Addresses { addresses })
     }
 
-    pub fn generate_diff_csv(&self) -> Result<(), Box<dyn Error>> {
+    pub fn to_csv(&self, original_file_name: &String) -> Result<(), Box<dyn Error>> {
+        // 1. Checking if the the directory `./results/` exist, if not creates it
+        // 1.5 Get the original_file_name and append `_gmaps_version.csv` to it
+        // 2. Create a `csv::Writer::from_path` with the `./results/` + `new_file_name`
+        // 3. Write the headers (can probably be skipped thanks to `serde` and `Record` type)
+        // 4. Looping through the `self.addresses` vector and write with the csv writer
         todo!()
     }
 

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -7,7 +7,7 @@ use crate::address::Address;
 #[derive(Debug)]
 pub struct MyGeocoding {
     map_client: GoogleMapsClient,
-    address_results: Vec<Address>,
+    pub address_results: Vec<Address>,
 }
 
 #[derive(Error, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, error::Error};
+use std::{env, error::Error, path::PathBuf, str::FromStr};
 
 use address::Addresses;
 use geocoding::MyGeocoding;
@@ -16,8 +16,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
     }
 
+    let file_path = PathBuf::from_str(&args[1])?;
+
     let mut geocoding = MyGeocoding::new().expect("API key should be an env variable");
 
+    // TODO: Change to PathBuf instead of String for new
     let old_addresses = Addresses::new(&args[1]).map_err(|e| e.to_string())?;
 
     // debugging print
@@ -42,6 +45,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
             .await;
     }
+
+    Addresses::addresses_to_csv(geocoding.address_results, &file_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Adding a way to generate a `.csv` result file.
This file contains the result for each address checked with the Google Maps API.

## Tasks

- [x] Create a function will serialize the `Address` struct.
- [x] Generate a file named: `{}_gmaps_version.csv` (where `{}` is the original file name)
- [x] Create the file in a folder named `result/` (to be created if it does not exist)
- [x] Contains `name,address,city,zip,country,administrative_area_level1,administrative_area_level2,lat,lng` headers
